### PR TITLE
Add support for different metric config from the default sensor config.

### DIFF
--- a/src/test/java/io/tehuti/metrics/stats/RateTest.java
+++ b/src/test/java/io/tehuti/metrics/stats/RateTest.java
@@ -97,4 +97,47 @@ public class RateTest {
         }
     }
 
+    /**
+     * This test case is used to verify the following issue:
+     * Metric will report wrong value if the sensor time-window/samples are
+     * different from the specific config for the associated metrics.
+     * Sensor record function is using its own metric config instead of the
+     * config controlled by each metric.
+     * Considering the following scenario:
+     * 1. Sensor is using the default 30s time-window;
+     * 2. The metric associated with this sensor is using 2s time-window;
+     * 3. When we record a value in the data sensor in the first second, the
+     *    metric will report the correct value since both sensor record and metric
+     *    measure functions are using the same window;
+     * 4. If we record another value after 5 seconds, the sensor will still
+     *    write to the same window because of the big 30s sensor time-window, but
+     *    the metric measure function will treat the sensor time-window to be
+     *    obsolete because the window was updated 5 seconds ago, then report 0;
+     */
+    @Test
+    public void testSupportDifferentMetricAndSensorConfigs() {
+        // Time window of sensor1 is 30s by default, and the time window of metricWith2Seconds is 2s.
+        Sensor sensor1 = metricsRepository.sensor("rateSensor1");
+        MetricConfig configWith2Seconds = new MetricConfig().timeWindow(2, TimeUnit.SECONDS);
+        Metric metricWith2Seconds = sensor1.add("metric_with_2_seconds.test", new Rate(TimeUnit.SECONDS), configWith2Seconds);
+
+        // Time window of sensor2 is 2s, and same as metricWithDefault2Seconds
+        Sensor sensor2 = metricsRepository.sensor("rateSensor2", new MetricConfig().timeWindow(2, TimeUnit.SECONDS));
+        Metric metricWithDefault2Seconds = sensor2.add("metric_with_default_2_seconds.test", new Rate(TimeUnit.SECONDS));
+
+        sensor1.record(100);
+        sensor2.record(100);
+        assertEquals(metricWith2Seconds.value(), metricWithDefault2Seconds.value(), 0);
+
+        time.sleep(1000);
+        sensor1.record(100);
+        sensor2.record(100);
+        assertEquals(metricWith2Seconds.value(), metricWithDefault2Seconds.value(), 0);
+
+        time.sleep(3000);
+        sensor1.record(100);
+        sensor2.record(100);
+        assertEquals(metricWith2Seconds.value(), metricWithDefault2Seconds.value(), 0);
+    }
+
 }


### PR DESCRIPTION
This change is used to address the following issue
Metric will report wrong value if the sensor time-window/samples are
different from the specific config for the associated metrics.
Sensor record function is using its own metric config instead of the
config controlled by each metric.
Considering the following scenario:
1. Sensor is using the default 30s time-window;
2. The metric associated with this sensor is using 2s time-window;
3. When we record a value in the data sensor in the first second, the
metric will report the correct value since both sensor record and metric
measure functions are using the same window;
4. If we record another value after 5 seconds, the sensor will still
write to the same window because of the big 30s sensor time-window, but
the metric measure function will treat the sensor time-window to be
obsolete because the window was updated 5 seconds ago, then report 0;