### PR TITLE
MetricsReporter is able to removeMetrics now.

### DIFF
--- a/src/main/java/io/tehuti/metrics/MetricsReporter.java
+++ b/src/main/java/io/tehuti/metrics/MetricsReporter.java
@@ -29,9 +29,22 @@ public interface MetricsReporter extends Configurable {
 
     /**
      * This is called whenever a metric is updated or added
+     * This method is deprecated since the method name is vague and
+     * it doesn't support removing metrics.
      * @param metric
      */
+    @Deprecated
     public void metricChange(TehutiMetric metric);
+
+    /**
+     * A better method for {@link MetricsReporter#metricChange(TehutiMetric)}
+     */
+    public void addMetric(TehutiMetric metric);
+
+    /**
+     * This is called when removing a metric that has already been registered
+     */
+    public void removeMetric(TehutiMetric metric);
 
     /**
      * Called when the metrics repository is closed.

--- a/src/main/java/io/tehuti/metrics/MetricsRepository.java
+++ b/src/main/java/io/tehuti/metrics/MetricsRepository.java
@@ -210,7 +210,7 @@ public class MetricsRepository {
             throw new IllegalArgumentException("A metric named '" + metric.name() + "' already exists, can't register another one.");
         this.metrics.put(metric.name(), metric);
         for (MetricsReporter reporter : reporters)
-            reporter.metricChange(metric);
+            reporter.addMetric(metric);
     }
 
     /**

--- a/src/main/java/io/tehuti/metrics/stats/Gauge.java
+++ b/src/main/java/io/tehuti/metrics/stats/Gauge.java
@@ -1,0 +1,30 @@
+package io.tehuti.metrics.stats;
+
+import io.tehuti.metrics.MeasurableStat;
+import io.tehuti.metrics.MetricConfig;
+
+/**
+ * simplest, un-windowed metric that returns the value passed into it
+ */
+public class Gauge implements MeasurableStat {
+
+  private double value;
+
+  public Gauge() {
+    this.value = Double.NaN;
+  }
+
+  public Gauge(double value) {
+    this.value = value;
+  }
+
+  @Override
+  public void record(MetricConfig config, double value, long now) {
+    this.value = value;
+  }
+
+  @Override
+  public double measure(MetricConfig config, long now) {
+    return this.value;
+  }
+}

--- a/src/main/java/io/tehuti/metrics/stats/SampledStat.java
+++ b/src/main/java/io/tehuti/metrics/stats/SampledStat.java
@@ -25,6 +25,18 @@ import io.tehuti.metrics.MetricConfig;
  *
  * All the samples are combined to produce the measurement. When a window is complete the oldest sample is cleared and
  * recycled to begin recording the next sample.
+ *
+ *    <-- sample -->  <-- sample -->  <-- sample -->  <-- sample -->  <-- sample -->  <-- sample -->
+ *  +---------------+---------------+---------------+---------------+---------------+---------------+
+ *  <------------------------------------- total sliding window ------------------------------------>
+ *
+ * The total sliding window is a circular list that contains numbers of sample.
+ * In a time-based sliding window, the length of the sliding window is "# of the sample" * "length of the sample".
+ * Since records that fall in the same sample will be aggregated, it is the "granularity" of the metric. Given a fix
+ * sliding window length, shortening the sample length makes a finer granularity. (more accurate)
+ *
+ * SampledStat is implemented in the lazy evaluation fashion. That being said the necessary widow update (removing
+ * obsolete samples) would not be done unless a query {@link SampledStat#measure(MetricConfig, long)} arrives.
  * 
  * Subclasses of this class define different statistics measured using this basic pattern.
  */

--- a/src/main/java/io/tehuti/metrics/stats/Total.java
+++ b/src/main/java/io/tehuti/metrics/stats/Total.java
@@ -14,7 +14,6 @@ package io.tehuti.metrics.stats;
 
 import io.tehuti.metrics.MeasurableStat;
 import io.tehuti.metrics.MetricConfig;
-
 /**
  * An un-windowed cumulative total maintained over all time.
  */


### PR DESCRIPTION
1.add MetricsReporter#addMetric, MetricsReporter#removeMetric
mark MetricsReporter#metricChange as deprecated

2.add synchronized blocks for TehutiMbean#getAttribute and
TehutiMbean#setAttribute to solve a potential race condition.

3. rename JmxReporter#reregister to register 
It should not be any compatible issue since this is private method used internally.