### PR TITLE
Allow sensor to check quota before recording the stat.

### DIFF
--- a/src/main/java/io/tehuti/metrics/Quota.java
+++ b/src/main/java/io/tehuti/metrics/Quota.java
@@ -23,18 +23,32 @@ public final class Quota {
 
     private final boolean upper;
     private final double bound;
+    private boolean checkQuotaBeforeRecord;
 
     public Quota(double bound, boolean upper) {
+        this(bound, upper, false);
+    }
+
+    public Quota(double bound, boolean upper, boolean checkQuotaBeforeRecord) {
         this.bound = bound;
         this.upper = upper;
+        this.checkQuotaBeforeRecord = checkQuotaBeforeRecord;
     }
 
     public static Quota lessThan(double upperBound) {
         return new Quota(upperBound, true);
     }
 
+    public static Quota lessThan(double upperBound, boolean checkQuotaBeforeRecord) {
+        return new Quota(upperBound, true, checkQuotaBeforeRecord);
+    }
+
     public static Quota moreThan(double lowerBound) {
         return new Quota(lowerBound, false);
+    }
+
+    public static Quota moreThan(double lowerBound, boolean checkQuotaBeforeRecord) {
+        return new Quota(lowerBound, false, checkQuotaBeforeRecord);
     }
 
     public boolean isUpperBound() {
@@ -45,8 +59,16 @@ public final class Quota {
         return this.bound;
     }
 
+    public boolean isCheckQuotaBeforeRecord() {
+        return checkQuotaBeforeRecord;
+    }
+
     public boolean acceptable(double value) {
-        return (upper && value <= bound) || (!upper && value >= bound);
+        if (checkQuotaBeforeRecord) {
+            return (upper && value < bound) || (!upper && value > bound);
+        } else {
+            return (upper && value <= bound) || (!upper && value >= bound);
+        }
     }
 
     public String toString() {

--- a/src/main/java/io/tehuti/metrics/Quota.java
+++ b/src/main/java/io/tehuti/metrics/Quota.java
@@ -23,32 +23,44 @@ public final class Quota {
 
     private final boolean upper;
     private final double bound;
-    private boolean checkQuotaBeforeRecord;
+    private boolean checkQuotaBeforeRecording;
 
     public Quota(double bound, boolean upper) {
         this(bound, upper, false);
     }
 
-    public Quota(double bound, boolean upper, boolean checkQuotaBeforeRecord) {
+    public Quota(double bound, boolean upper, boolean checkQuotaBeforeRecording) {
         this.bound = bound;
         this.upper = upper;
-        this.checkQuotaBeforeRecord = checkQuotaBeforeRecord;
+        this.checkQuotaBeforeRecording = checkQuotaBeforeRecording;
     }
 
     public static Quota lessThan(double upperBound) {
         return new Quota(upperBound, true);
     }
 
-    public static Quota lessThan(double upperBound, boolean checkQuotaBeforeRecord) {
-        return new Quota(upperBound, true, checkQuotaBeforeRecord);
+    /**
+     * Create a quota object to limit the maximum usage.
+     * If checkQuotaBeforeRecording is set to true for any of the metrics registered in a sensor, then this can
+     * short-circuit the recording for ALL metrics tied to that sensor, even if some of them are configured with
+     * checkQuotaBeforeRecording set to false.
+     */
+    public static Quota lessThan(double upperBound, boolean checkQuotaBeforeRecording) {
+      return new Quota(upperBound, true, checkQuotaBeforeRecording);
     }
 
     public static Quota moreThan(double lowerBound) {
         return new Quota(lowerBound, false);
     }
 
-    public static Quota moreThan(double lowerBound, boolean checkQuotaBeforeRecord) {
-        return new Quota(lowerBound, false, checkQuotaBeforeRecord);
+    /**
+     * Create a quota object to limit the minimum usage.
+     * If checkQuotaBeforeRecording is set to true for any of the metrics registered in a sensor, then this can
+     * short-circuit the recording for ALL metrics tied to that sensor, even if some of them are configured with
+     * checkQuotaBeforeRecording set to false.
+     */
+    public static Quota moreThan(double lowerBound, boolean checkQuotaBeforeRecording) {
+        return new Quota(lowerBound, false, checkQuotaBeforeRecording);
     }
 
     public boolean isUpperBound() {
@@ -59,12 +71,12 @@ public final class Quota {
         return this.bound;
     }
 
-    public boolean isCheckQuotaBeforeRecord() {
-        return checkQuotaBeforeRecord;
+    public boolean isCheckQuotaBeforeRecording() {
+        return checkQuotaBeforeRecording;
     }
 
     public boolean acceptable(double value) {
-        if (checkQuotaBeforeRecord) {
+        if (checkQuotaBeforeRecording) {
             return (upper && value < bound) || (!upper && value > bound);
         } else {
             return (upper && value <= bound) || (!upper && value >= bound);

--- a/src/main/java/io/tehuti/metrics/Sensor.java
+++ b/src/main/java/io/tehuti/metrics/Sensor.java
@@ -123,7 +123,7 @@ public final class Sensor {
                 if (quota != null) {
                     // Only check the quota on the right time. If quota is set to check quota before recording,
                     // only verify the usage in pre-check round.
-                    if (quota.isCheckQuotaBeforeRecord() ^ preCheck) {
+                    if (quota.isCheckQuotaBeforeRecording() ^ preCheck) {
                         continue;
                     }
                     double value = metric.value(timeMs);

--- a/src/test/java/io/tehuti/metrics/MetricsTest.java
+++ b/src/test/java/io/tehuti/metrics/MetricsTest.java
@@ -172,7 +172,7 @@ public class MetricsTest {
     }
 
     @Test
-    public void testCheckQuotaBeforeRecord() {
+    public void testCheckQuotaBeforeRecording() {
         Sensor sensor = metricsRepository.sensor("test");
         double quota = 10.0;
         sensor.add("test1.total", new Total(),

--- a/src/test/java/io/tehuti/metrics/MetricsTest.java
+++ b/src/test/java/io/tehuti/metrics/MetricsTest.java
@@ -172,6 +172,22 @@ public class MetricsTest {
     }
 
     @Test
+    public void testCheckQuotaBeforeRecord() {
+        Sensor sensor = metricsRepository.sensor("test");
+        double quota = 10.0;
+        sensor.add("test1.total", new Total(),
+            new MetricConfig().quota(Quota.lessThan(quota, true)));
+        sensor.record(quota);
+        try {
+            sensor.record(1);
+            fail("Should have gotten a quota violation.");
+        } catch (QuotaViolationException e) {
+            // expected
+        }
+        assertEquals(quota, metricsRepository.metrics().get("test1.total").value(), EPS);
+    }
+
+    @Test
     public void testPercentiles() {
         int buckets = 100;
         Percentiles percs = new Percentiles(4 * buckets,


### PR DESCRIPTION
Add a boolean field in metric config to enable/disable checking quota before recording.
Change the logic of sensor that if usage equals to the quota, throw quota violation exception.