### PR TITLE
Fix the issue of check quota before recording the usage.

### DIFF
--- a/src/main/java/io/tehuti/metrics/Quota.java
+++ b/src/main/java/io/tehuti/metrics/Quota.java
@@ -76,11 +76,7 @@ public final class Quota {
     }
 
     public boolean acceptable(double value) {
-        if (checkQuotaBeforeRecording) {
-            return (upper && value < bound) || (!upper && value > bound);
-        } else {
-            return (upper && value <= bound) || (!upper && value >= bound);
-        }
+        return (upper && value <= bound) || (!upper && value >= bound);
     }
 
     public String toString() {


### PR DESCRIPTION
The last commit has a issue. We should get the sum of the current usage and the usage of incoming request, then compare this sum with quota while checking the quota before recording the usage.
For example: quota = 10, current usage= 9, the usage of incoming request is 2. Sensor should throw the exception because 9+2>10 it means the potential usage exceeds the quota. If the usage of incoming request is 1, 9+1=10, so we should accept this request.