### PR TITLE
Fix the pre-check quota issue for rate sensor.

### DIFF
--- a/src/main/java/io/tehuti/metrics/Measurable.java
+++ b/src/main/java/io/tehuti/metrics/Measurable.java
@@ -25,4 +25,15 @@ public interface Measurable {
      */
     public double measure(MetricConfig config, long now);
 
+    /**
+     * Measure this quantity with an extra value and return the result as a double
+     *
+     * @param config The configuration for this metric
+     * @param now The POSIX time in milliseconds the measurement is being taken
+     * @param extraValue the value need to be counted in the current measurement
+     * @return The measured value
+     */
+    default double measureWithExtraValue(MetricConfig config, long now, double extraValue) {
+        return measure(config, now) + extraValue;
+    }
 }

--- a/src/main/java/io/tehuti/metrics/QuotaViolationException.java
+++ b/src/main/java/io/tehuti/metrics/QuotaViolationException.java
@@ -28,7 +28,7 @@ public class QuotaViolationException extends TehutiException {
     private final double value;
 
     public QuotaViolationException(String m, double value) {
-        super(m);
+        super(m + ", current value is: " + value);
         this.value = value;
     }
 

--- a/src/main/java/io/tehuti/metrics/Sensor.java
+++ b/src/main/java/io/tehuti/metrics/Sensor.java
@@ -128,7 +128,7 @@ public final class Sensor {
                     }
                     // If we check quota before recording, we should count on the value of the current request.
                     // So we could prevent the usage of current request exceeding the quota.
-                    double value = preCheck? requestedValue + metric.value(timeMs): metric.value(timeMs);
+                    double value = preCheck? metric.extraValue(timeMs, requestedValue): metric.value(timeMs);
                     if (!quota.acceptable(value)) {
                         throw new QuotaViolationException(
                             "Metric " + metric.name() + " is in violation of its " + quota.toString(), value);

--- a/src/main/java/io/tehuti/metrics/TehutiMetric.java
+++ b/src/main/java/io/tehuti/metrics/TehutiMetric.java
@@ -65,9 +65,29 @@ public final class TehutiMetric implements Metric {
         }
     }
 
+    /**
+     * Return the current value of the measurement.
+     *
+     * @param timeMs
+     *
+     * @return
+     */
     double value(long timeMs) {
         return this.measurable.measure(config, timeMs);
     }
+
+    /**
+     * Return the current value plus extra value we gave of this measurement.
+     *
+     * @param timeMs
+     * @param extraValue
+     *
+     * @return
+     */
+    double extraValue(long timeMs, double extraValue) {
+        return this.measurable.measureWithExtraValue(config, timeMs, extraValue);
+    }
+
 
     public void config(MetricConfig config) {
         synchronized (lock) {

--- a/src/main/java/io/tehuti/metrics/stats/Rate.java
+++ b/src/main/java/io/tehuti/metrics/stats/Rate.java
@@ -57,7 +57,16 @@ public class Rate implements MeasurableStat {
 
     @Override
     public double measure(MetricConfig config, long now) {
-        double value = stat.measure(config, now);
+        return measureWithExtraValue(config, now, 0);
+    }
+
+    @Override
+    public double measureWithExtraValue(MetricConfig config, long now, double extraValue) {
+        if (!(stat instanceof SampledTotal)) {
+            throw new UnsupportedOperationException(
+                "Do NOT support measure with extra value for stat: " + stat.getClass().getName());
+        }
+        double value = stat.measure(config, now) + extraValue;
         if (value == 0) {
             return 0;
         } else {


### PR DESCRIPTION
For rate sensor the value we used to compare with quota should be usage/elapsed. So once we do the pre-check, we should aslo use the same rule to compute the request value.No the value we used to compare with quota should be (usage+requestValue)/elapsed.