### PR TITLE
Allow optional ExecutorService in MetricsRepository

### DIFF
--- a/src/main/java/io/tehuti/metrics/AsyncGaugeConfig.java
+++ b/src/main/java/io/tehuti/metrics/AsyncGaugeConfig.java
@@ -1,0 +1,37 @@
+package io.tehuti.metrics;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Configuration for AsyncGauge
+ */
+public class AsyncGaugeConfig {
+  // Thread pool for metrics measurement; ideally these threads should be daemon threads
+  private final ExecutorService metricsMeasurementExecutor;
+  // The max time to wait for metrics measurement to complete
+  // If this limit is exceeded, the measurement task in the thread pool will be cancelled
+  private final long maxMetricsMeasurementTimeoutInMs;
+  // After the metrics measurement task is submitted to the thread pool, it will try to wait for this amount of time;
+  // if this limit is exceeded, AsyncGauge will return the cached value
+  private final long initialMetricsMeasurementTimeoutInMs;
+
+  public AsyncGaugeConfig(ExecutorService metricsMeasurementExecutor,
+                          long maxMetricsMeasurementTimeoutInMs,
+                          long initialMetricsMeasurementTimeoutInMs) {
+    this.metricsMeasurementExecutor = metricsMeasurementExecutor;
+    this.maxMetricsMeasurementTimeoutInMs = maxMetricsMeasurementTimeoutInMs;
+    this.initialMetricsMeasurementTimeoutInMs = initialMetricsMeasurementTimeoutInMs;
+  }
+
+  public ExecutorService getMetricsMeasurementExecutor() {
+    return metricsMeasurementExecutor;
+  }
+
+  public long getMaxMetricsMeasurementTimeoutInMs() {
+    return maxMetricsMeasurementTimeoutInMs;
+  }
+
+  public long getInitialMetricsMeasurementTimeoutInMs() {
+    return initialMetricsMeasurementTimeoutInMs;
+  }
+}

--- a/src/main/java/io/tehuti/metrics/MetricsRepository.java
+++ b/src/main/java/io/tehuti/metrics/MetricsRepository.java
@@ -269,25 +269,12 @@ public class MetricsRepository {
     }
 
     /**
-     * Ungraceful shutdown of all the metrics maintained by this metrics repository.
-     * The thread pool used for measuring metrics will be shutdown immediately; any users of this thread pool
-     * will be impacted immediately; user of this thread pool needs to handle the shutdown appropriately.
-     *
-     * Close this metrics repository.
-     */
-    public void close() {
-        this.metricsMeasurementExecutor.ifPresent(ExecutorService::shutdownNow);
-        for (MetricsReporter reporter : this.reporters)
-            reporter.close();
-    }
-
-    /**
      * Graceful shutdown of all the metrics maintained by this metrics repository.
      * The thread pool used for measuring metrics will be shutdown at the end.
      *
      * Close this metrics repository.
      */
-    public void gracefulClose() {
+    public void close() {
         for (MetricsReporter reporter : this.reporters)
             reporter.close();
         this.metricsMeasurementExecutor.ifPresent(ExecutorService::shutdownNow);

--- a/src/main/java/io/tehuti/metrics/MetricsRepository.java
+++ b/src/main/java/io/tehuti/metrics/MetricsRepository.java
@@ -56,7 +56,7 @@ public class MetricsRepository {
     private final ConcurrentMap<String, Sensor> sensors;
     private final List<MetricsReporter> reporters;
     private final Time time;
-    private final Optional<ExecutorService> metricsMeasurementExecutor;
+    private final Optional<ExecutorService> asyncGaugeMeasurementExecutor;
 
     /**
      * Create a metrics repository with no metric reporters and default configuration.
@@ -65,8 +65,8 @@ public class MetricsRepository {
         this(Optional.empty());
     }
 
-    public MetricsRepository(Optional<ExecutorService> metricsMeasurementExecutor) {
-        this(new MetricConfig(), metricsMeasurementExecutor);
+    public MetricsRepository(Optional<ExecutorService> asyncGaugeMeasurementExecutor) {
+        this(new MetricConfig(), asyncGaugeMeasurementExecutor);
     }
 
     /**
@@ -76,8 +76,8 @@ public class MetricsRepository {
         this(time, Optional.empty());
     }
 
-    public MetricsRepository(Time time, Optional<ExecutorService> metricsMeasurementExecutor) {
-        this(new MetricConfig(), new ArrayList<>(0), time, metricsMeasurementExecutor);
+    public MetricsRepository(Time time, Optional<ExecutorService> asyncGaugeMeasurementExecutor) {
+        this(new MetricConfig(), new ArrayList<>(0), time, asyncGaugeMeasurementExecutor);
     }
 
     /**
@@ -89,8 +89,8 @@ public class MetricsRepository {
         this(defaultConfig, Optional.empty());
     }
 
-    public MetricsRepository(MetricConfig defaultConfig, Optional<ExecutorService> metricsMeasurementExecutor) {
-        this(defaultConfig, new ArrayList<>(0), new SystemTime(), metricsMeasurementExecutor);
+    public MetricsRepository(MetricConfig defaultConfig, Optional<ExecutorService> asyncGaugeMeasurementExecutor) {
+        this(defaultConfig, new ArrayList<>(0), new SystemTime(), asyncGaugeMeasurementExecutor);
     }
 
     /**
@@ -98,15 +98,15 @@ public class MetricsRepository {
      * @param defaultConfig The default config
      * @param reporters The metrics reporters
      * @param time The time instance to use with the metrics
-     * @param metricsMeasurementExecutor Optional thread pool to improve performance of metrics measurement
+     * @param asyncGaugeMeasurementExecutor Optional thread pool to improve performance of metrics measurement
      */
-    public MetricsRepository(MetricConfig defaultConfig, List<MetricsReporter> reporters, Time time, Optional<ExecutorService> metricsMeasurementExecutor) {
+    public MetricsRepository(MetricConfig defaultConfig, List<MetricsReporter> reporters, Time time, Optional<ExecutorService> asyncGaugeMeasurementExecutor) {
         this.config = Utils.notNull(defaultConfig);
         this.sensors = new ConcurrentHashMap<>();
         this.metrics = new ConcurrentHashMap<>();
         this.reporters = Utils.notNull(reporters);
         this.time = time;
-        this.metricsMeasurementExecutor = metricsMeasurementExecutor;
+        this.asyncGaugeMeasurementExecutor = asyncGaugeMeasurementExecutor;
         for (MetricsReporter reporter : reporters)
             reporter.init(new ArrayList<>());
     }
@@ -264,8 +264,8 @@ public class MetricsRepository {
         return this.metrics.get(name);
     }
 
-    public Optional<ExecutorService> getMetricsMeasurementExecutor() {
-        return this.metricsMeasurementExecutor;
+    public Optional<ExecutorService> getAsyncGaugeMeasurementExecutor() {
+        return this.asyncGaugeMeasurementExecutor;
     }
 
     /**
@@ -277,6 +277,6 @@ public class MetricsRepository {
     public void close() {
         for (MetricsReporter reporter : this.reporters)
             reporter.close();
-        this.metricsMeasurementExecutor.ifPresent(ExecutorService::shutdownNow);
+        this.asyncGaugeMeasurementExecutor.ifPresent(ExecutorService::shutdownNow);
     }
 }

--- a/src/main/java/io/tehuti/metrics/NamedMeasurableStat.java
+++ b/src/main/java/io/tehuti/metrics/NamedMeasurableStat.java
@@ -1,0 +1,8 @@
+package io.tehuti.metrics;
+
+/**
+ * A NamedMeasurableStat is a MeasurableStat that has a name.
+ */
+public interface NamedMeasurableStat extends MeasurableStat {
+  String getStatName();
+}

--- a/src/main/java/io/tehuti/metrics/SimpleMeasurable.java
+++ b/src/main/java/io/tehuti/metrics/SimpleMeasurable.java
@@ -1,0 +1,12 @@
+package io.tehuti.metrics;
+
+/**
+ * A SimpleMeasurable doesn't care about time; the default implementation just does the measurement.
+ */
+public interface SimpleMeasurable extends Measurable {
+  default double measure(MetricConfig config, long now) {
+    return measure();
+  }
+
+  double measure();
+}

--- a/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
+++ b/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
@@ -1,0 +1,123 @@
+package io.tehuti.metrics.stats;
+
+import io.tehuti.metrics.Measurable;
+import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.NamedMeasurableStat;
+import io.tehuti.metrics.SimpleMeasurable;
+import io.tehuti.utils.RedundantLogFilter;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+
+/**
+ * A gauge metric type that will measure the value for at most 500ms; if the measurement takes longer than 500ms, it will
+ * return the cached value. This is useful for metrics that are expensive to measure.
+ */
+public class AsyncGauge implements NamedMeasurableStat {
+  private static final Logger LOGGER = LogManager.getLogger(AsyncGauge.class);
+  private static final RedundantLogFilter REDUNDANT_LOG_FILTER = RedundantLogFilter.getRedundantLogFilter();
+
+  private final ExecutorService metricValueMeasurementThreadPool;
+  private final String metricName;
+  private double cachedMeasurement = 0.0;
+  private long lastMeasurementStartTimeInMs = System.currentTimeMillis();
+  private CompletableFuture<Double> lastMeasurementFuture = null;
+
+  private final Measurable measurable;
+
+  public AsyncGauge(Measurable measurable, ExecutorService metricValueMeasurementThreadPool, String metricName) {
+    this.measurable = measurable;
+    this.metricValueMeasurementThreadPool = metricValueMeasurementThreadPool;
+    this.metricName = metricName;
+  }
+
+  public AsyncGauge(SimpleMeasurable measurable, ExecutorService metricValueMeasurementThreadPool, String metricName) {
+    this.measurable = measurable;
+    this.metricValueMeasurementThreadPool = metricValueMeasurementThreadPool;
+    this.metricName = metricName;
+  }
+
+  @Override
+  public String getStatName() {
+    return metricName;
+  }
+
+  @Override
+  public void record(double value, long now) {
+    throw new UnsupportedOperationException("AsyncGauge does not support record(double, long); the invalid usage happened to metric " + metricName);
+  }
+
+  /**
+   * In AsyncGauge, the actual measurement will be treated as an async task carried out by the thread pool. Once
+   * the measurement task is submitted, the method will return the cached value immediately (so this value will be 1 minute stale)
+   * @param config The configuration for this metric
+   * @param now The POSIX time in milliseconds the measurement is being taken
+   * @return
+   */
+  @Override
+  public double measure(MetricConfig config, long now) {
+    // If the thread pool is shutdown, return the cached value
+    if (metricValueMeasurementThreadPool.isShutdown()) {
+      return cachedMeasurement;
+    }
+    // If the last measurement future exists, meaning the last measurement didn't finish fast enough. In this case:
+    // 1. If the last measurement future is done, update the cached value, log which metric measurement is slow.
+    // 2. If the last measurement future is still running, cancel it to prevent OutOfMemory issue, and log.
+    if (lastMeasurementFuture != null) {
+      if (lastMeasurementFuture.isDone()) {
+        try {
+          cachedMeasurement = lastMeasurementFuture.get();
+          long measurementTimeInMs = System.currentTimeMillis() - lastMeasurementStartTimeInMs;
+          String warningMessagePrefix = String.format("The measurement for metric %s", metricName);
+          if (!REDUNDANT_LOG_FILTER.isRedundantLog(warningMessagePrefix)) {
+            LOGGER.warn(String.format("%s took %d ms; the metric value is %f", warningMessagePrefix, measurementTimeInMs,
+                cachedMeasurement));
+          }
+        } catch (ExecutionException e) {
+          String errorMessage = String.format("Failed to get a done measurement future for metric %s. ", metricName);
+          if (!REDUNDANT_LOG_FILTER.isRedundantLog(errorMessage)) {
+            LOGGER.error(errorMessage, e);
+          }
+        } catch (InterruptedException e) {
+          throw new RuntimeException("Metric measurement is interrupted for metric " + metricName, e);
+        }
+      } else {
+        lastMeasurementFuture.cancel(true);
+        String warningMessagePrefix = String.format(
+            "The last measurement for metric %s is still running. " + "Cancel it to prevent OutOfMemory issue.",
+            metricName);
+        if (!REDUNDANT_LOG_FILTER.isRedundantLog(warningMessagePrefix)) {
+          LOGGER.warn(String.format("%s Return the cached value: %f", warningMessagePrefix, cachedMeasurement));
+        }
+      }
+    }
+
+    // Submit a new measurement task for the current minute
+    lastMeasurementStartTimeInMs = System.currentTimeMillis();
+    lastMeasurementFuture =
+        CompletableFuture.supplyAsync(() -> this.measurable.measure(config, now), metricValueMeasurementThreadPool);
+    // Try to wait for the CompletableFuture for up to 500ms. If it times out, return the cached value;
+    // otherwise, update the cached value and return the latest result.
+    try {
+      cachedMeasurement = lastMeasurementFuture.get(500, TimeUnit.MILLISECONDS);
+      lastMeasurementFuture = null;
+      return cachedMeasurement;
+    } catch (TimeoutException e) {
+      // Do nothing; the cached value will be returned
+      return cachedMeasurement;
+    } catch (ExecutionException e) {
+      String errorMessage = String.format("Error when measuring value for metric %s.", metricName);
+      if (!REDUNDANT_LOG_FILTER.isRedundantLog(errorMessage)) {
+        LOGGER.error(errorMessage, e);
+      }
+      return cachedMeasurement;
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Metric measurement is interrupted for metric " + metricName, e);
+    }
+  }
+}

--- a/src/main/java/io/tehuti/utils/RedundantLogFilter.java
+++ b/src/main/java/io/tehuti/utils/RedundantLogFilter.java
@@ -1,0 +1,83 @@
+package io.tehuti.utils;
+
+import java.util.BitSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class RedundantLogFilter {
+  public static final int DEFAULT_BITSET_SIZE = 8 * 1024 * 1024 * 16; // 16MB
+  public static final long DEFAULT_NO_REDUNDANT_LOG_DURATION_MS = TimeUnit.MINUTES.toMillis(10); // 10 minute
+
+  private static RedundantLogFilter singleton;
+
+  private final int bitSetSize;
+  private final ScheduledExecutorService cleanerExecutor = Executors.newScheduledThreadPool(1);
+
+  private BitSet activeBitset;
+  private BitSet oldBitSet;
+
+  public RedundantLogFilter() {
+    this(DEFAULT_BITSET_SIZE, DEFAULT_NO_REDUNDANT_LOG_DURATION_MS);
+  }
+
+  public RedundantLogFilter(int bitSetSize, long noRedundantLogDurationMs) {
+    this.bitSetSize = bitSetSize;
+    activeBitset = new BitSet(bitSetSize);
+    oldBitSet = new BitSet(bitSetSize);
+    cleanerExecutor.scheduleAtFixedRate(
+        this::clearBitSet,
+        noRedundantLogDurationMs,
+        noRedundantLogDurationMs,
+        TimeUnit.MILLISECONDS);
+  }
+
+  public synchronized static RedundantLogFilter getRedundantLogFilter() {
+    if (singleton == null) {
+      singleton = new RedundantLogFilter(DEFAULT_BITSET_SIZE, DEFAULT_NO_REDUNDANT_LOG_DURATION_MS);
+    }
+    return singleton;
+  }
+
+  public boolean isRedundantLog(String logMessage) {
+    return isRedundantLog(logMessage, true);
+  }
+
+  public boolean isRedundantLog(String logMessage, boolean updateRedundancy) {
+    if (logMessage == null) {
+      return true;
+    }
+    int index = getIndex(logMessage);
+    return isRedundant(index, updateRedundancy);
+  }
+
+  public final void clearBitSet() {
+    synchronized (this) {
+      // Swap bit sets so we are not blocked by clear operation.
+      BitSet temp = oldBitSet;
+      oldBitSet = activeBitset;
+      activeBitset = temp;
+    }
+    oldBitSet.clear();
+  }
+
+  public void shutdown() {
+    cleanerExecutor.shutdownNow();
+  }
+
+  protected int getIndex(String key) {
+    return Math.abs((key).hashCode() % bitSetSize);
+  }
+
+  protected boolean isRedundant(int index, boolean updateRedundancy) {
+    if (!activeBitset.get(index)) {
+      // It's possible that we found the bit was not set, then activeBitset is changed, and we set the bit in the new
+      // set. But it doesn't matter.
+      if (updateRedundancy) {
+        activeBitset.set(index);
+      }
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/test/java/io/tehuti/metrics/MetricsTest.java
+++ b/src/test/java/io/tehuti/metrics/MetricsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.fail;
 
 import io.tehuti.utils.Time;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import io.tehuti.Metric;
@@ -33,7 +34,7 @@ public class MetricsTest {
 
     MockTime time = new MockTime();
     MetricConfig config = new MetricConfig();
-    MetricsRepository metricsRepository = new MetricsRepository(config, Arrays.asList((MetricsReporter) new JmxReporter()), time);
+    MetricsRepository metricsRepository = new MetricsRepository(config, Arrays.asList((MetricsReporter) new JmxReporter()), time, Optional.empty());
 
     @Test
     public void testSimpleStats() throws Exception {

--- a/src/test/java/io/tehuti/metrics/stats/RateTest.java
+++ b/src/test/java/io/tehuti/metrics/stats/RateTest.java
@@ -1,5 +1,6 @@
 package io.tehuti.metrics.stats;
 
+import java.util.Optional;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 import io.tehuti.Metric;
@@ -17,7 +18,7 @@ public class RateTest {
     long timeWindow = 10000;
 
     MockTime time = new MockTime();
-    MetricsRepository metricsRepository = new MetricsRepository(new MetricConfig(), Arrays.asList((MetricsReporter) new JmxReporter()), time);
+    MetricsRepository metricsRepository = new MetricsRepository(new MetricConfig(), Arrays.asList((MetricsReporter) new JmxReporter()), time, Optional.empty());
 
     Logger logger = Logger.getLogger(this.getClass());
 


### PR DESCRIPTION
This PR adds support for optional ExecutorService in MetricsRepository; metrics could consider using this thread pool to improve metric measurement performance.

Other changes:
Added a new interface called NamedMeasurableStat, which is also a MeasurableStat but can return stat name.