### PR TITLE
AsyncGauge returns error code for when measurement breaches max timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.tehuti
 archivesBaseName=tehuti
-version=0.11.0
+version=0.11.1
 
 signing.enabled=false
 signing.keyId=

--- a/src/main/java/io/tehuti/metrics/AsyncGaugeConfig.java
+++ b/src/main/java/io/tehuti/metrics/AsyncGaugeConfig.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ExecutorService;
  * Configuration for AsyncGauge
  */
 public class AsyncGaugeConfig {
-  private static final long DEFAULT_MAX_TIMEOUT_ERROR_CODE = -1L;
+  public static final long DEFAULT_MAX_TIMEOUT_ERROR_CODE = -1L;
 
   // Thread pool for metrics measurement; ideally these threads should be daemon threads
   private final ExecutorService metricsMeasurementExecutor;

--- a/src/main/java/io/tehuti/metrics/AsyncGaugeConfig.java
+++ b/src/main/java/io/tehuti/metrics/AsyncGaugeConfig.java
@@ -7,6 +7,8 @@ import java.util.concurrent.ExecutorService;
  * Configuration for AsyncGauge
  */
 public class AsyncGaugeConfig {
+  private static final long DEFAULT_MAX_TIMEOUT_ERROR_CODE = -1L;
+
   // Thread pool for metrics measurement; ideally these threads should be daemon threads
   private final ExecutorService metricsMeasurementExecutor;
   // The max time to wait for metrics measurement to complete
@@ -16,9 +18,19 @@ public class AsyncGaugeConfig {
   // if this limit is exceeded, AsyncGauge will return the cached value
   private final long initialMetricsMeasurementTimeoutInMs;
 
+  // The error code returned by the measurement task when it is cancelled due to the max timeout limit
+  private final long maxTimeoutErrorCode;
+
   public AsyncGaugeConfig(ExecutorService metricsMeasurementExecutor,
                           long maxMetricsMeasurementTimeoutInMs,
                           long initialMetricsMeasurementTimeoutInMs) {
+    this(metricsMeasurementExecutor, maxMetricsMeasurementTimeoutInMs, initialMetricsMeasurementTimeoutInMs, DEFAULT_MAX_TIMEOUT_ERROR_CODE);
+  }
+
+  public AsyncGaugeConfig(ExecutorService metricsMeasurementExecutor,
+                          long maxMetricsMeasurementTimeoutInMs,
+                          long initialMetricsMeasurementTimeoutInMs,
+                          long maxTimeoutErrorCode) {
     Utils.notNull(metricsMeasurementExecutor);
     if (maxMetricsMeasurementTimeoutInMs <= 0) {
       throw new IllegalArgumentException("maxMetricsMeasurementTimeoutInMs must be positive");
@@ -29,6 +41,7 @@ public class AsyncGaugeConfig {
     this.metricsMeasurementExecutor = metricsMeasurementExecutor;
     this.maxMetricsMeasurementTimeoutInMs = maxMetricsMeasurementTimeoutInMs;
     this.initialMetricsMeasurementTimeoutInMs = initialMetricsMeasurementTimeoutInMs;
+    this.maxTimeoutErrorCode = maxTimeoutErrorCode;
   }
 
   public ExecutorService getMetricsMeasurementExecutor() {
@@ -41,5 +54,9 @@ public class AsyncGaugeConfig {
 
   public long getInitialMetricsMeasurementTimeoutInMs() {
     return initialMetricsMeasurementTimeoutInMs;
+  }
+
+  public long getMaxTimeoutErrorCode() {
+    return maxTimeoutErrorCode;
   }
 }

--- a/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
+++ b/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
@@ -46,16 +46,9 @@ public class AsyncGauge implements NamedMeasurableStat {
     return metricName;
   }
 
-  /**
-   * WARNING: Using record() on AsyncGauge will not update any stat value, because the stat value is measured through
-   *          a function which is passed through constructor. However, the record() method is still implemented in order
-   *          not to allow using this stat together with other stats in the same metric Sensor.
-   * @param value  The value to record
-   * @param now The POSIX time in milliseconds this value occurred
-   */
   @Override
   public void record(double value, long now) {
-    // Do nothing
+    throw new UnsupportedOperationException("AsyncGauge does not support record(double, long); the invalid usage happened to metric " + metricName);
   }
 
   /**

--- a/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
+++ b/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
@@ -46,9 +46,16 @@ public class AsyncGauge implements NamedMeasurableStat {
     return metricName;
   }
 
+  /**
+   * WARNING: Using record() on AsyncGauge will not update any stat value, because the stat value is measured through
+   *          a function which is passed through constructor. However, the record() method is still implemented in order
+   *          not to allow using this stat together with other stats in the same metric Sensor.
+   * @param value  The value to record
+   * @param now The POSIX time in milliseconds this value occurred
+   */
   @Override
   public void record(double value, long now) {
-    throw new UnsupportedOperationException("AsyncGauge does not support record(double, long); the invalid usage happened to metric " + metricName);
+    // Do nothing
   }
 
   /**
@@ -105,12 +112,13 @@ public class AsyncGauge implements NamedMeasurableStat {
         if (System.currentTimeMillis() - lastMeasurementStartTimeInMs < asyncGaugeConfig.getMaxMetricsMeasurementTimeoutInMs()) {
           return cachedMeasurement;
         } else {
+          cachedMeasurement = asyncGaugeConfig.getMaxTimeoutErrorCode();
           lastMeasurementFuture.cancel(true);
           String warningMessagePrefix = String.format(
               "The last measurement for metric %s is still running. " + "Cancel it to prevent OutOfMemory issue.",
               metricName);
           if (!REDUNDANT_LOG_FILTER.isRedundantLog(warningMessagePrefix)) {
-            LOGGER.warn(String.format("%s Return the cached value: %f", warningMessagePrefix, cachedMeasurement));
+            LOGGER.warn(String.format("%s Return the error code: %f", warningMessagePrefix, cachedMeasurement));
           }
           return submitNewMeasurementTask(config, now, asyncGaugeConfig);
         }

--- a/src/test/java/io/tehuti/metrics/stats/AsyncGaugeTest.java
+++ b/src/test/java/io/tehuti/metrics/stats/AsyncGaugeTest.java
@@ -1,0 +1,66 @@
+package io.tehuti.metrics.stats;
+
+import static org.junit.Assert.assertEquals;
+
+import io.tehuti.metrics.AsyncGaugeConfig;
+import io.tehuti.metrics.MetricConfig;
+import java.util.concurrent.Executors;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class AsyncGaugeTest {
+  @Test
+  public void testTimeoutMeasurementReturnsErrorCode() throws InterruptedException {
+    // Create a AsyncGauge metric whose measurement will block forever
+    AsyncGauge gauge = new AsyncGauge((c, t) -> {
+      try {
+        // Block forever
+        Thread.sleep(Long.MAX_VALUE);
+      } catch (InterruptedException e) {
+        // Interrupt will unblock the measurement
+      }
+      return 0.0;
+    }, "testMetric");
+    // Set AsyncGaugeConfig with max timeout of 100 ms and initial timeout of 10 ms
+    AsyncGaugeConfig asyncGaugeConfig = new AsyncGaugeConfig(Executors.newSingleThreadExecutor(), 100, 10);
+    MetricConfig metricConfig = new MetricConfig(asyncGaugeConfig);
+    // The first measurement should return 0 because the measurement task will not complete after the initial timeout
+    assertEquals("The first measurement should return 0 because the measurement task will not complete after the initial timeout",
+        0.0, gauge.measure(metricConfig, System.currentTimeMillis()), 0.01);
+    // Wait for the max timeout
+    Thread.sleep(101);
+    /**
+     * The second measurement should return {@link AsyncGaugeConfig#DEFAULT_MAX_TIMEOUT_ERROR_CODE} because the
+     * measurement task will not complete after the max timeout
+     */
+    assertEquals("The second measurement should return error code",
+        AsyncGaugeConfig.DEFAULT_MAX_TIMEOUT_ERROR_CODE, gauge.measure(metricConfig, System.currentTimeMillis()), 0.01);
+  }
+
+  @Test(timeout = 10000)
+  public void testCallerOfAsyncGaugeWillNeverBeBlocked() {
+    // Create a AsyncGauge metric whose measurement will block forever even if it's interrupted
+    AsyncGauge gauge = new AsyncGauge((c, t) -> {
+      while (true) {
+        try {
+          // Block forever
+          Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException e) {
+          // Continue the endless loop
+        }
+      }
+    }, "testMetric");
+    // Set AsyncGaugeConfig with max timeout of 100 ms, initial timeout of 10 ms and a daemon thread pool
+    AsyncGaugeConfig asyncGaugeConfig = new AsyncGaugeConfig(Executors.newSingleThreadExecutor(r -> {
+      Thread thread = new Thread(r);
+      thread.setDaemon(true);
+      return thread;
+    }), 100, 10);
+    MetricConfig metricConfig = new MetricConfig(asyncGaugeConfig);
+    // Test that caller of AsyncGauge.measure() will never be blocked
+    gauge.measure(metricConfig, System.currentTimeMillis());
+    // If the caller is blocked, the following line will never be executed
+    System.out.println("Caller of AsyncGauge.measure() is not blocked");
+  }
+}


### PR DESCRIPTION
By default, the error code is -1, but it will be configurable.