### PR TITLE
Added DaemonThreadFactory to avoid hanging in the tehuti application

### DIFF
--- a/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
+++ b/src/main/java/io/tehuti/metrics/stats/AsyncGauge.java
@@ -4,6 +4,7 @@ import io.tehuti.metrics.AsyncGaugeConfig;
 import io.tehuti.metrics.Measurable;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.NamedMeasurableStat;
+import io.tehuti.utils.DaemonThreadFactory;
 import io.tehuti.utils.RedundantLogFilter;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -30,11 +31,10 @@ public class AsyncGauge implements NamedMeasurableStat {
   private final Measurable measurable;
 
   public static final AsyncGaugeConfig DEFAULT_ASYNC_GAUGE_CONFIG =
-      new AsyncGaugeConfig(Executors.newFixedThreadPool(10, r -> {
-        Thread thread = new Thread(r);
-        thread.setDaemon(true); // Set the thread as daemon
-        return thread;
-      }), TimeUnit.MINUTES.toMillis(1), 500);
+      new AsyncGaugeConfig(Executors.newFixedThreadPool(10,
+          new DaemonThreadFactory("Default_Async_Gauge_Executor")),
+          TimeUnit.MINUTES.toMillis(1),
+          500);
 
   public AsyncGauge(Measurable measurable, String metricName) {
     this.measurable = measurable;

--- a/src/main/java/io/tehuti/utils/DaemonThreadFactory.java
+++ b/src/main/java/io/tehuti/utils/DaemonThreadFactory.java
@@ -1,0 +1,22 @@
+package io.tehuti.utils;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class DaemonThreadFactory implements ThreadFactory {
+  private final AtomicInteger threadNumber;
+  private final String namePrefix;
+
+  public DaemonThreadFactory(String threadNamePrefix) {
+    this.threadNumber = new AtomicInteger(1);
+    this.namePrefix = threadNamePrefix;
+  }
+
+  public Thread newThread(Runnable r) {
+    Thread t = new Thread(r, namePrefix + "-t" + threadNumber.getAndIncrement());
+    t.setDaemon(true);
+    return t;
+  }
+
+}

--- a/src/main/java/io/tehuti/utils/RedundantLogFilter.java
+++ b/src/main/java/io/tehuti/utils/RedundantLogFilter.java
@@ -12,7 +12,7 @@ public class RedundantLogFilter {
   private static RedundantLogFilter singleton;
 
   private final int bitSetSize;
-  private final ScheduledExecutorService cleanerExecutor = Executors.newScheduledThreadPool(1);
+  private final ScheduledExecutorService cleanerExecutor = Executors.newScheduledThreadPool(1, new DaemonThreadFactory("Redundant_Log_Filter"));
 
   private BitSet activeBitset;
   private BitSet oldBitSet;

--- a/src/test/java/io/tehuti/utils/RedundantLogFilterTest.java
+++ b/src/test/java/io/tehuti/utils/RedundantLogFilterTest.java
@@ -1,0 +1,10 @@
+package io.tehuti.utils;
+
+
+public class RedundantLogFilterTest {
+
+  public static void main(String[] args) throws InterruptedException {
+    RedundantLogFilter logFilter = new RedundantLogFilter(10, 1000);
+    logFilter.isRedundantLog("test");
+  }
+}


### PR DESCRIPTION
Previously, 'RedundantLogFilter' is using non-daemon thread to clean up the log filter, and it would result in stuck application if the application doesn't invoke 'RedundantLogFilter#shutdown', which is error prone. This PR adds a 'DaemonThreadFactory', so that the log filter threads won't block Tehuti application shutdown even it doesn't invoke 'RedundantLogFilter#shutdown' explicitly.