### PR TITLE
Fix the order of locking between MetricRepository and Sensor to prevent deadlock

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.tehuti
 archivesBaseName=tehuti
-version=0.12.2
+version=0.12.3
 
 signing.enabled=false
 signing.keyId=

--- a/src/test/java/io/tehuti/utils/LockOrderTest.java
+++ b/src/test/java/io/tehuti/utils/LockOrderTest.java
@@ -1,0 +1,74 @@
+package io.tehuti.utils;
+
+import io.tehuti.metrics.JmxReporter;
+import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Avg;
+import java.util.Arrays;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+
+public class LockOrderTest {
+  /**
+   * Test to make sure operations take MetricsRepository lock first and the sensor lock after that.
+   * The test should finish promptly without any deadlock.
+   */
+  @Test(timeout = 10 * Time.MS_PER_SECOND)
+  public void testLockOrderOfMetricRepositoryAndSensor() throws Exception {
+    MockTime time = new MockTime();
+    MetricConfig config = new MetricConfig();
+    MetricsRepository
+        metricsRepository = new MetricsRepository(config, Arrays.asList(new JmxReporter()), time);
+
+    Sensor s = metricsRepository.sensor("test.sensor");
+    s.add("test.Avg", new Avg());
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    CyclicBarrier barrierForBothThreadsToRunTogether = new CyclicBarrier(2);
+    CyclicBarrier barrierToWaitForBothThreadsToComplete = new CyclicBarrier(3);
+
+    // thread 1
+    executor.submit(() -> {
+      try {
+        barrierForBothThreadsToRunTogether.await();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      metricsRepository.removeSensor("test.sensor");
+      try {
+        barrierToWaitForBothThreadsToComplete.await();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    // thread 2
+    executor.submit(() -> {
+      try {
+        barrierForBothThreadsToRunTogether.await();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      s.add("test1.Avg", new Avg());
+      try {
+        barrierToWaitForBothThreadsToComplete.await();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    try {
+      barrierToWaitForBothThreadsToComplete.await();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    executor.shutdown();
+    executor.awaitTermination(1, TimeUnit.MINUTES);
+  }
+}


### PR DESCRIPTION
Currently lock on `MetricRepository` is taken first and then `Sensor`'s lock is taken in some cases and the opposite is happening is some other cases, leading to deadlock if both these cases happen around the same time. Fix is to change the order of locking to always take lock on `MetricRepository` first and then take `Sensor`'s lock whenever the `MetricRepository` is accessed in `Sensor` to prevent deadlock.